### PR TITLE
Fix securityconfig-update job not working at bootstrap time

### DIFF
--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -196,9 +196,9 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 		clusterHostName := BuildClusterSvcHostName(r.instance)
 		httpPort, securityconfigPath := helpers.VersionCheck(r.instance)
 		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, clusterHostName, httpPort) +
+			fmt.Sprintf(ApplyAllYmlCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort) +
 			fmt.Sprintf(ApplyDisableAutoExpandConfigurationCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort) +
-			fmt.Sprintf(ApplyReplicaConfigurationCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort) +
-			fmt.Sprintf(ApplyAllYmlCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort)
+			fmt.Sprintf(ApplyReplicaConfigurationCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort)
 	}
 
 	r.logger.Info("Starting securityconfig update job")

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -46,28 +46,16 @@ do
 echo 'Waiting to connect to the cluster'; sleep 120;
 done;`
 
-	// CRITEO - Disable auto-expand replica because it doesn't work with rackawareness in the current version (using --disable-replica-autoexpand)
-	//          Add 2 replicas (+ primary, so RF3) (using --update_settings 3)
-	ApplyReplicaConfigurationCmdTmpl = `count=0;
-until $ADMIN -ts /usr/share/opensearch/jdk/lib/security/cacerts -cert %s -key %s -cd %s -icl -nhnv --update_settings 2 -h %s -p %v || (( count++ >= 20 ));
-do
-sleep 20;
-done;`
-
-	ApplyDisableAutoExpandConfigurationCmdTmpl = `count=0;
-until $ADMIN -ts /usr/share/opensearch/jdk/lib/security/cacerts -cert %s -key %s -cd %s -icl -nhnv --disable-replica-autoexpand -h %s -p %v || (( count++ >= 20 ));
-do
-sleep 20;
-done;`
-
+	// CRITEO - Add --explicit-replicas 0-2 to force .opendistro_security index to be created with auto-expand mode enabled, up to 2 replicas
 	ApplyAllYmlCmdTmpl = `count=0;
-until $ADMIN -ts /usr/share/opensearch/jdk/lib/security/cacerts -cert %s -key %s -cd %s -icl -nhnv -h %s -p %v || (( count++ >= 20 ));
+until $ADMIN -ts /usr/share/opensearch/jdk/lib/security/cacerts -cert %s -key %s -cd %s --explicit-replicas 0-2 -icl -nhnv -h %s -p %v || (( count++ >= 20 ));
 do
 sleep 20;
 done;`
 
+	// CRITEO - Add --explicit-replicas 0-2 to force .opendistro_security index to be created with auto-expand mode enabled, up to 2 replicas
 	ApplySingleYmlCmdTmpl = `count=0;
-until $ADMIN -ts /usr/share/opensearch/jdk/lib/security/cacerts -cert %s -key %s -f %s -t %s -icl -nhnv -h %s -p %v || (( count++ >= 20 ));
+until $ADMIN -ts /usr/share/opensearch/jdk/lib/security/cacerts -cert %s -key %s -f %s -t %s --explicit-replicas 0-2 -icl -nhnv -h %s -p %v || (( count++ >= 20 ));
 do
 sleep 20;
 done;`
@@ -196,9 +184,7 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 		clusterHostName := BuildClusterSvcHostName(r.instance)
 		httpPort, securityconfigPath := helpers.VersionCheck(r.instance)
 		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, clusterHostName, httpPort) +
-			fmt.Sprintf(ApplyAllYmlCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort) +
-			fmt.Sprintf(ApplyDisableAutoExpandConfigurationCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort) +
-			fmt.Sprintf(ApplyReplicaConfigurationCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort)
+			fmt.Sprintf(ApplyAllYmlCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort)
 	}
 
 	r.logger.Info("Starting securityconfig update job")
@@ -228,9 +214,7 @@ func BuildCmdArg(instance *opsterv1.OpenSearchCluster, secret *corev1.Secret, lo
 	clusterHostName := BuildClusterSvcHostName(instance)
 	httpPort, securityconfigPath := helpers.VersionCheck(instance)
 
-	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, clusterHostName, httpPort) +
-		fmt.Sprintf(ApplyDisableAutoExpandConfigurationCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort) +
-		fmt.Sprintf(ApplyReplicaConfigurationCmdTmpl, adminCert, adminKey, securityconfigPath, clusterHostName, httpPort)
+	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, clusterHostName, httpPort)
 
 	// Get the list of yml files and sort them
 	// This will ensure commands are always generated in the same order


### PR DESCRIPTION
Previous commit https://github.com/criteo-forks/opensearch-k8s-operator/commit/2749630073ae9bb2c454893a3212454c10415051 is not working at bootstrap phase.

securityconfig-update job is trying to update settings of .opendistro_security index whereas it is not yet created, causing bootstrap delay of 800s, errors and finally index not setup as expected.

reworking the initial proposal:
* to keep auto-expand mode but limiting number of replicas to two.
* to not try to update existing index setup (it's one shot action that can be done manually)
* to reduce the diff with upstream
