### PR TITLE
Use node/pod IP instead of node name

### DIFF
--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -364,7 +364,15 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opsterv1.NodePool) error {
 		return err
 	}
 
-	ready, err = services.PreparePodForDelete(r.osClient, workingPod, r.instance.Spec.General.DrainDataNodes, dataCount)
+	// CRITEO WORKAROUND: use node ip
+	podIp, err := helpers.ReplicaHostIpByPodName(r.ctx, r.Client, *sts, workingPod)
+	if err != nil {
+		conditions = append(conditions, fmt.Sprintf("Failed to resolve IP for pod %s on %s", workingPod, pool.Component))
+		r.setComponentConditions(conditions, pool.Component)
+		return err
+	}
+
+	ready, err = services.PreparePodForDeleteByIp(r.osClient, podIp, r.instance.Spec.General.DrainDataNodes, dataCount)
 	if err != nil {
 		conditions = append(conditions, "Could not prepare pod for delete")
 		r.setComponentConditions(conditions, pool.Component)
@@ -392,8 +400,9 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opsterv1.NodePool) error {
 	r.setComponentConditions(conditions, pool.Component)
 
 	// If we are draining nodes remove the exclusion after the pod is deleted
+	// CRITEO WORKAROUND: use node ip
 	if r.instance.Spec.General.DrainDataNodes {
-		_, err = services.RemoveExcludeNodeHost(r.osClient, workingPod)
+		_, err = services.RemoveExcludeNodeHostIp(r.osClient, podIp)
 		return err
 	}
 


### PR DESCRIPTION
Because node host name doesn't match pod name like the operator expects it to (at Criteo), we need to filter nodes by IP instead to get some operations (like node exclude, "has shards on node", etc.) to work. As such:

* Add methods that take in a node/pod IP (they're the same as we are using host networking) instead of node/pod name. We make copies of existing functions instead of modifying them, to make future rebases easier
* Blanket-modify top-level functions to use these new functions (like in scaler.go)
* Augment log messages of the latter to display node/pod IP when necessary