### PR TITLE
smartScaler: Check for green status before drain

### DIFF
--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Cluster Reconciler", func() {
 
 			Eventually(func() bool {
 				stsList := &appsv1.StatefulSetList{}
-				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Name))
+				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Namespace))
 				if err != nil {
 					return false
 				}

--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -289,6 +289,20 @@ func CheckClusterStatusForRestart(service *OsClusterClient, drainNodes bool) (bo
 	return false, "enabled shard allocation", nil
 }
 
+// CRITEO WORKAROUND: check Green cluster status for Scaler
+func IsClusterGreen(service *OsClusterClient) (bool, string, error) {
+	health, err := service.GetHealth()
+	if err != nil {
+		return false, "failed to fetch health", err
+	}
+
+	if health.Status == "green" {
+		return true, "", nil
+	}
+
+	return false, "cluster not green", nil
+}
+
 func ReactivateShardAllocation(service *OsClusterClient) error {
 	flatSettings, err := service.GetFlatClusterSettings()
 	if err != nil {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -138,6 +138,7 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool,
 		err := r.drainNode(currentStatus, currentSts, nodePool.Component)
 		return true, err
 	}
+
 	if currentStatus.Status == "Drained" {
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Start to Drain %s/%s", r.instance.Namespace, r.instance.Name)
 
@@ -301,11 +302,20 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 	if err != nil {
 		return err
 	}
+
 	nodeNotEmpty, err := services.HasShardsOnNodeIp(clusterClient, podIp)
 	if nodeNotEmpty {
 		lg.Info(fmt.Sprintf("Group-%s . draining node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
 		return err
 	}
+
+	// CRITEO WORKAROUND: Wait for cluster to be green
+	clusterNotGreen, _, err := services.IsClusterGreen(clusterClient)
+	if clusterNotGreen {
+		lg.Info(fmt.Sprintf("Group-%s . draining node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
+		return err
+	}
+
 	success, err := services.RemoveExcludeNodeHostIp(clusterClient, podIp)
 	if !success {
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Group-%s . node %s node is empty but node is still excluded from allocation (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp)
@@ -333,7 +343,8 @@ func (r *ScalerReconciler) cleanupStatefulSets(result *reconciler.CombinedResult
 	if err := r.Client.List(
 		r.ctx,
 		stsList,
-		client.InNamespace(r.instance.Name),
+		// CRITEO WORKAROUND: use "Namespace" instead of "Name"
+		client.InNamespace(r.instance.Namespace),
 		client.MatchingLabels{helpers.ClusterLabel: r.instance.Name},
 	); err != nil {
 		result.Combine(&ctrl.Result{}, err)
@@ -398,6 +409,21 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 			RequeueAfter: 15 * time.Second,
 		}, nil
 	}
+
+	// CRITEO WORKAROUND: Wait for cluster to be green
+	clusterNotGreen, msg, err := services.IsClusterGreen(clusterClient)
+	if err != nil {
+		lg.Error(err, msg)
+		return nil, err
+	}
+
+	if clusterNotGreen {
+		return &ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: 15 * time.Second,
+		}, nil
+	}
+	// END OF CRITEO WORKAROUND
 
 	if workingOrdinal == 0 {
 		result, err := r.ReconcileResource(&sts, reconciler.StateAbsent)

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -310,8 +310,8 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 	}
 
 	// CRITEO WORKAROUND: Wait for cluster to be green
-	clusterNotGreen, _, err := services.IsClusterGreen(clusterClient)
-	if clusterNotGreen {
+	clusterGreen, _, err := services.IsClusterGreen(clusterClient)
+	if !clusterGreen {
 		lg.Info(fmt.Sprintf("Group-%s . draining node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
 		return err
 	}
@@ -411,13 +411,13 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	}
 
 	// CRITEO WORKAROUND: Wait for cluster to be green
-	clusterNotGreen, msg, err := services.IsClusterGreen(clusterClient)
+	clusterGreen, msg, err := services.IsClusterGreen(clusterClient)
 	if err != nil {
 		lg.Error(err, msg)
 		return nil, err
 	}
 
-	if clusterNotGreen {
+	if !clusterGreen {
 		return &ctrl.Result{
 			Requeue:      true,
 			RequeueAfter: 15 * time.Second,


### PR DESCRIPTION
* Operator was checking only that the excluded ip has no more shards before draining it.
* Now we wait also for shards to be re-allocated
* Bonus: Make the cleanup of STS works ** It was checking the cluster name and not namespace when listing sts
** Added the green status check before draining