### PR TITLE
Revert "Use node/pod IP instead of node name"

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -9,9 +9,6 @@ import (
 
 var ClusterSettingsExcludeBrokenPath = []string{"cluster", "routing", "allocation", "exclude", "_name"}
 
-// CRITEO WORKAROUND: use node ip
-var ClusterSettingsExcludeBrokenPathIp = []string{"cluster", "routing", "allocation", "exclude", "_ip"}
-
 type ClusterSettingsAllocation string
 
 const (
@@ -47,21 +44,6 @@ func HasShardsOnNode(service *OsClusterClient, nodeName string) (bool, error) {
 	return false, err
 }
 
-// CRITEO WORKAROUND: use node ip
-func HasShardsOnNodeIp(service *OsClusterClient, ip string) (bool, error) {
-	var headers []string
-	response, err := service.CatShards(headers)
-	if err != nil {
-		return false, err
-	}
-	for _, shardsData := range response {
-		if shardsData.Ip == ip {
-			return true, err
-		}
-	}
-	return false, err
-}
-
 func HasIndexPrimariesOnNode(service *OsClusterClient, nodeName string, indices []string) (bool, error) {
 	var headers []string
 	response, err := service.CatNamedIndicesShards(headers, indices)
@@ -75,26 +57,6 @@ func HasIndexPrimariesOnNode(service *OsClusterClient, nodeName string, indices 
 		}
 		// If there are system shards on the node consider it not empty
 		if shardsData.NodeName == nodeName && shardsData.PrimaryOrReplica == "p" {
-			return true, nil
-		}
-	}
-	return false, err
-}
-
-// CRITEO WORKAROUND: use node ip
-func HasIndexPrimariesOnNodeIp(service *OsClusterClient, ip string, indices []string) (bool, error) {
-	var headers []string
-	response, err := service.CatNamedIndicesShards(headers, indices)
-	if err != nil {
-		return false, err
-	}
-	for _, shardsData := range response {
-		// If primary shards are still initializing consider the node not empty
-		if shardsData.PrimaryOrReplica == "p" && shardsData.State != "STARTED" {
-			return true, nil
-		}
-		// If there are system shards on the node consider it not empty
-		if shardsData.Ip == ip && shardsData.PrimaryOrReplica == "p" {
 			return true, nil
 		}
 	}
@@ -149,56 +111,6 @@ func RemoveExcludeNodeHost(service *OsClusterClient, nodeNameToExclude string) (
 	return err == nil, err
 }
 
-// CRITEO WORKAROUND: use node ip
-func AppendExcludeNodeHostIp(service *OsClusterClient, ipToExclude string) (bool, error) {
-	response, err := service.GetClusterSettings()
-	if err != nil {
-		return false, err
-	}
-	val, ok := helpers.FindByPath(response.Transient, ClusterSettingsExcludeBrokenPathIp)
-	var valAsString = ipToExclude
-	if ok && val != "" {
-		// Test whether name is already excluded
-		var found bool
-		valArr := strings.Split(val.(string), ",")
-		for _, name := range valArr {
-			if name == ipToExclude {
-				found = true
-				break
-			}
-		}
-		if !found {
-			valArr = append(valArr, ipToExclude)
-		}
-
-		valAsString = strings.Join(valArr, ",")
-	}
-	settings := createClusterSettingsResponseWithExcludeIp(valAsString)
-	if err == nil {
-		_, err = service.PutClusterSettings(settings)
-	}
-	return err == nil, err
-}
-
-// CRITEO WORKAROUND: use node ip
-func RemoveExcludeNodeHostIp(service *OsClusterClient, ipToExclude string) (bool, error) {
-	response, err := service.GetClusterSettings()
-	if err != nil {
-		return false, err
-	}
-	val, ok := helpers.FindByPath(response.Transient, ClusterSettingsExcludeBrokenPathIp)
-	if !ok || val == "" {
-		return true, err
-	}
-	valAsString := strings.ReplaceAll(val.(string), ipToExclude, "")
-	valAsString = strings.ReplaceAll(valAsString, ",,", ",")
-	settings := createClusterSettingsResponseWithExcludeIp(valAsString)
-	if err == nil {
-		_, err = service.PutClusterSettings(settings)
-	}
-	return err == nil, err
-}
-
 func SetClusterShardAllocation(service *OsClusterClient, enableType ClusterSettingsAllocation) error {
 	settings := createClusterSettingsAllocationEnable(enableType)
 	_, err := service.PutClusterSettings(settings)
@@ -216,25 +128,6 @@ func createClusterSettingsResponseWithExcludeName(exclude string) responses.Clus
 				"allocation": map[string]interface{}{
 					"exclude": map[string]interface{}{
 						"_name": val,
-					},
-				},
-			},
-		},
-	}}
-}
-
-// CRITEO WORKAROUND: use node ip
-func createClusterSettingsResponseWithExcludeIp(exclude string) responses.ClusterSettingsResponse {
-	var val *string = nil
-	if exclude != "" {
-		val = &exclude
-	}
-	return responses.ClusterSettingsResponse{Transient: map[string]interface{}{
-		"cluster": map[string]interface{}{
-			"routing": map[string]interface{}{
-				"allocation": map[string]interface{}{
-					"exclude": map[string]interface{}{
-						"_ip": val,
 					},
 				},
 			},
@@ -342,44 +235,6 @@ func PreparePodForDelete(service *OsClusterClient, podName string, drainNode boo
 
 		// Check if there are any shards on the node
 		nodeNotEmpty, err := HasShardsOnNode(service, podName)
-		if err != nil {
-			return false, err
-		}
-		// If the node isn't empty requeue to wait for shards to drain
-		return !nodeNotEmpty, nil
-	}
-	// Update cluster routing before deleting appropriate ordinal pod
-	if err := SetClusterShardAllocation(service, ClusterSettingsAllocationPrimaries); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// CRITEO WORKAROUND: use node ip
-func PreparePodForDeleteByIp(service *OsClusterClient, podIp string, drainNode bool, nodeCount int32) (bool, error) {
-	if drainNode {
-		// If we are draining nodes then drain the working node
-		_, err := AppendExcludeNodeHostIp(service, podIp)
-		if err != nil {
-			return false, err
-		}
-
-		// If there are only 2 data nodes only check for system indics
-		if nodeCount == 2 {
-			systemIndices, err := GetExistingSystemIndices(service)
-			if err != nil {
-				return false, err
-			}
-
-			systemPrimaries, err := HasIndexPrimariesOnNodeIp(service, podIp, systemIndices)
-			if err != nil {
-				return false, err
-			}
-			return !systemPrimaries, nil
-		}
-
-		// Check if there are any shards on the node
-		nodeNotEmpty, err := HasShardsOnNodeIp(service, podIp)
 		if err != nil {
 			return false, err
 		}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -428,26 +428,6 @@ func ReplicaHostName(currentSts appsv1.StatefulSet, repNum int32) string {
 	return fmt.Sprintf("%s-%d", currentSts.ObjectMeta.Name, repNum)
 }
 
-// CRITEO workaround
-func ReplicaHostIpByPodName(ctx context.Context, k8sClient client.Client, currentSts appsv1.StatefulSet, podName string) (string, error) {
-	pod := &corev1.Pod{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: podName, Namespace: currentSts.Namespace}, pod); err != nil {
-		return "", err
-	}
-
-	if pod.Status.PodIP == "" {
-		// Handle pending pod
-		return "", fmt.Errorf("tried to get IP of pod %s while it is pending", podName)
-	}
-
-	return pod.Status.PodIP, nil
-}
-
-// CRITEO workaround
-func ReplicaHostIp(ctx context.Context, k8sClient client.Client, currentSts appsv1.StatefulSet, repNum int32) (string, error) {
-	return ReplicaHostIpByPodName(ctx, k8sClient, currentSts, ReplicaHostName(currentSts, repNum))
-}
-
 func WorkingPodForRollingRestart(ctx context.Context, k8sClient client.Client, sts *appsv1.StatefulSet) (string, error) {
 	replicas := lo.FromPtrOr(sts.Spec.Replicas, 1)
 	// Handle the simple case

--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -192,13 +192,7 @@ func (r *RollingRestartReconciler) restartStatefulSetPod(sts *appsv1.StatefulSet
 		return ctrl.Result{}, err
 	}
 
-	// CRITEO WORKAROUND: use node ip
-	podIp, err := helpers.ReplicaHostIpByPodName(r.ctx, r.Client, *sts, workingPod)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	ready, err = services.PreparePodForDeleteByIp(r.osClient, podIp, r.instance.Spec.General.DrainDataNodes, dataCount)
+	ready, err = services.PreparePodForDelete(r.osClient, workingPod, r.instance.Spec.General.DrainDataNodes, dataCount)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -225,9 +219,8 @@ func (r *RollingRestartReconciler) restartStatefulSetPod(sts *appsv1.StatefulSet
 	}
 
 	// If we are draining nodes remove the exclusion after the pod is deleted
-	// CRITEO WORKAROUND: use node ip
 	if r.instance.Spec.General.DrainDataNodes {
-		_, err = services.RemoveExcludeNodeHostIp(r.osClient, podIp)
+		_, err = services.RemoveExcludeNodeHost(r.osClient, workingPod)
 		return ctrl.Result{}, err
 	}
 

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -169,23 +169,14 @@ func (r *ScalerReconciler) decreaseOneNode(currentStatus opsterv1.ComponentStatu
 	*currentSts.Spec.Replicas--
 	annotations := map[string]string{"cluster-name": r.instance.GetName()}
 	lastReplicaNodeName := helpers.ReplicaHostName(currentSts, *currentSts.Spec.Replicas)
-
-	// CRITEO WORKAROUND: use node ip
-	podIp, err := helpers.ReplicaHostIp(r.ctx, r.Client, currentSts, *currentSts.Spec.Replicas)
-
+	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Start to decreaseing node %s on %s ", lastReplicaNodeName, nodePoolGroupName)
+	_, err := r.ReconcileResource(&currentSts, reconciler.StatePresent)
 	if err != nil {
-		lg.Error(err, "Failed to resolve IP for pod %s on %s", lastReplicaNodeName, nodePoolGroupName)
-		return false, err
-	}
-
-	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Start to decreasing node %s on %s (IP: %s)", lastReplicaNodeName, nodePoolGroupName, podIp)
-	_, err = r.ReconcileResource(&currentSts, reconciler.StatePresent)
-	if err != nil {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Failed to remove node - Group-%s . Failed to remove node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp)
-		lg.Error(err, fmt.Sprintf("failed to remove node %s (IP: %s)", lastReplicaNodeName, podIp))
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Failed to remove node - Group-%s . Failed to remove node %s", nodePoolGroupName, lastReplicaNodeName)
+		lg.Error(err, fmt.Sprintf("failed to remove node %s", lastReplicaNodeName))
 		return true, err
 	}
-	lg.Info(fmt.Sprintf("Group-%s . removed node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
+	lg.Info(fmt.Sprintf("Group-%s . removed node %s", nodePoolGroupName, lastReplicaNodeName))
 	r.instance.Status.ComponentsStatus = helpers.RemoveIt(currentStatus, r.instance.Status.ComponentsStatus)
 	err = r.Status().Update(r.ctx, r.instance)
 	if err != nil {
@@ -203,14 +194,14 @@ func (r *ScalerReconciler) decreaseOneNode(currentStatus opsterv1.ComponentStatu
 	clusterClient, err := services.NewOsClusterClient(builders.URLForCluster(r.instance), username, password)
 	if err != nil {
 		lg.Error(err, "failed to create os client")
-		r.recorder.AnnotatedEventf(r.instance, annotations, "WARN", "failed to remove node exclude", "Group-%s . failed to remove node exclude %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "WARN", "failed to remove node exclude", "Group-%s . failed to remove node exclude %s", nodePoolGroupName, lastReplicaNodeName)
 		return true, err
 	}
 
-	success, err := services.RemoveExcludeNodeHostIp(clusterClient, podIp)
+	success, err := services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
 	if !success || err != nil {
-		lg.Error(err, fmt.Sprintf("failed to remove exclude node %s (IP %s)", lastReplicaNodeName, podIp))
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to remove node exclude - Group-%s , node  %s (IP %s)", nodePoolGroupName, lastReplicaNodeName, podIp)
+		lg.Error(err, fmt.Sprintf("failed to remove exclude node %s", lastReplicaNodeName))
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to remove node exclude - Group-%s , node  %s", nodePoolGroupName, lastReplicaNodeName)
 	}
 
 	return false, err
@@ -233,16 +224,9 @@ func (r *ScalerReconciler) excludeNode(currentStatus opsterv1.ComponentStatus, c
 	// -----  Now start remove node ------
 	lastReplicaNodeName := helpers.ReplicaHostName(currentSts, *currentSts.Spec.Replicas-1)
 
-	// CRITEO WORKAROUND: use node ip
-	podIp, err := helpers.ReplicaHostIp(r.ctx, r.Client, currentSts, *currentSts.Spec.Replicas-1)
+	excluded, err := services.AppendExcludeNodeHost(clusterClient, lastReplicaNodeName)
 	if err != nil {
-		lg.Error(err, "Failed to resolve IP for pod %s on %s", lastReplicaNodeName, nodePoolGroupName)
-		return err
-	}
-
-	excluded, err := services.AppendExcludeNodeHostIp(clusterClient, podIp)
-	if err != nil {
-		lg.Error(err, fmt.Sprintf("failed to exclude node %s (IP: %s)", lastReplicaNodeName, podIp))
+		lg.Error(err, fmt.Sprintf("failed to exclude node %s", lastReplicaNodeName))
 		return err
 	}
 	if excluded {
@@ -252,7 +236,7 @@ func (r *ScalerReconciler) excludeNode(currentStatus opsterv1.ComponentStatus, c
 			Description: nodePoolGroupName,
 		}
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Finished to Exclude %s/%s", r.instance.Namespace, r.instance.Name)
-		lg.Info(fmt.Sprintf("Group-%s .excluded node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
+		lg.Info(fmt.Sprintf("Group-%s .excluded node %s", nodePoolGroupName, lastReplicaNodeName))
 		r.instance.Status.ComponentsStatus = helpers.Replace(currentStatus, componentStatus, r.instance.Status.ComponentsStatus)
 		err = r.Status().Update(r.ctx, r.instance)
 		if err != nil {
@@ -270,11 +254,11 @@ func (r *ScalerReconciler) excludeNode(currentStatus opsterv1.ComponentStatus, c
 		Description: nodePoolGroupName,
 	}
 	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Start sacle %s/%s from %d to %d", r.instance.Namespace, r.instance.Name, *currentSts.Spec.Replicas, *currentSts.Spec.Replicas-1)
-	lg.Info(fmt.Sprintf("Group-%s . Failed to exclude node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
+	lg.Info(fmt.Sprintf("Group-%s . Failed to exclude node %s", nodePoolGroupName, lastReplicaNodeName))
 	r.instance.Status.ComponentsStatus = helpers.Replace(currentStatus, componentStatus, r.instance.Status.ComponentsStatus)
 	err = r.Status().Update(r.ctx, r.instance)
 	if err != nil {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Group-%s . failed to remove node exclude %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Group-%s . failed to remove node exclude %s", nodePoolGroupName, lastReplicaNodeName)
 		lg.Error(err, "failed to update status")
 		return err
 	}
@@ -291,34 +275,26 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 		return err
 	}
 
-	// CRITEO WORKAROUND: use node ip
-	podIp, err := helpers.ReplicaHostIp(r.ctx, r.Client, currentSts, *currentSts.Spec.Replicas-1)
-	if err != nil {
-		lg.Error(err, "Failed to resolve IP for pod %s on %s", lastReplicaNodeName, nodePoolGroupName)
-		return err
-	}
-
 	clusterClient, err := services.NewOsClusterClient(builders.URLForCluster(r.instance), username, password)
 	if err != nil {
 		return err
 	}
-
-	nodeNotEmpty, err := services.HasShardsOnNodeIp(clusterClient, podIp)
+	nodeNotEmpty, err := services.HasShardsOnNode(clusterClient, lastReplicaNodeName)
 	if nodeNotEmpty {
-		lg.Info(fmt.Sprintf("Group-%s . draining node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
+		lg.Info(fmt.Sprintf("Group-%s . draining node %s", nodePoolGroupName, lastReplicaNodeName))
 		return err
 	}
 
 	// CRITEO WORKAROUND: Wait for cluster to be green
 	clusterGreen, _, err := services.IsClusterGreen(clusterClient)
 	if !clusterGreen {
-		lg.Info(fmt.Sprintf("Group-%s . draining node %s (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
+		lg.Info(fmt.Sprintf("Group-%s . draining node %s", nodePoolGroupName, lastReplicaNodeName))
 		return err
 	}
 
-	success, err := services.RemoveExcludeNodeHostIp(clusterClient, podIp)
+	success, err := services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
 	if !success {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Group-%s . node %s node is empty but node is still excluded from allocation (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp)
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Group-%s . node %s node is empty but node is still excluded from allocation", nodePoolGroupName, lastReplicaNodeName)
 		return err
 	}
 
@@ -327,7 +303,7 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 		Status:      "Drained",
 		Description: nodePoolGroupName,
 	}
-	lg.Info(fmt.Sprintf("Group-%s .node %s node is drained (IP: %s)", nodePoolGroupName, lastReplicaNodeName, podIp))
+	lg.Info(fmt.Sprintf("Group-%s .node %s node is drained", nodePoolGroupName, lastReplicaNodeName))
 	r.instance.Status.ComponentsStatus = helpers.Replace(currentStatus, componentStatus, r.instance.Status.ComponentsStatus)
 	err = r.Status().Update(r.ctx, r.instance)
 	if err != nil {
@@ -380,23 +356,14 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Finished os client for scaling ")
 
 	workingOrdinal := pointer.Int32Deref(sts.Spec.Replicas, 1) - 1
-
 	lastReplicaNodeName := helpers.ReplicaHostName(sts, workingOrdinal)
-
-	// CRITEO WORKAROUND: use node ip
-	podIp, err := helpers.ReplicaHostIp(r.ctx, r.Client, sts, workingOrdinal)
+	_, err = services.AppendExcludeNodeHost(clusterClient, lastReplicaNodeName)
 	if err != nil {
-		lg.Error(err, "Failed to resolve IP for pod %s", lastReplicaNodeName)
+		lg.Error(err, fmt.Sprintf("failed to exclude node %s", lastReplicaNodeName))
 		return nil, err
 	}
 
-	_, err = services.AppendExcludeNodeHostIp(clusterClient, podIp)
-	if err != nil {
-		lg.Error(err, fmt.Sprintf("failed to exclude node %s (IP: %s)", lastReplicaNodeName, podIp))
-		return nil, err
-	}
-
-	nodeNotEmpty, err := services.HasShardsOnNodeIp(clusterClient, podIp)
+	nodeNotEmpty, err := services.HasShardsOnNode(clusterClient, lastReplicaNodeName)
 	if err != nil {
 		lg.Error(err, "failed to check shards on node")
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to check shards on node")
@@ -430,9 +397,9 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 		if err != nil {
 			return result, err
 		}
-		_, err = services.RemoveExcludeNodeHostIp(clusterClient, podIp)
+		_, err = services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
 		if err != nil {
-			lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s (IP: %s)", lastReplicaNodeName, podIp))
+			lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
 		}
 		return result, err
 	}
@@ -443,9 +410,9 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 		return result, err
 	}
 
-	_, err = services.RemoveExcludeNodeHostIp(clusterClient, podIp)
+	_, err = services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
 	if err != nil {
-		lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s (IP: %s)", lastReplicaNodeName, podIp))
+		lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
 	}
 	r.recorder.AnnotatedEventf(r.instance, annotations, "Noraml", "Scaler", "Finished scaling")
 	return result, err

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -374,15 +374,7 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opsterv1.NodePool) error {
 		return err
 	}
 
-	// CRITEO WORKAROUND: use node ip
-	podIp, err := helpers.ReplicaHostIpByPodName(r.ctx, r.Client, *sts, workingPod)
-	if err != nil {
-		conditions = append(conditions, fmt.Sprintf("Failed to resolve IP for pod %s on %s", workingPod, pool.Component))
-		r.setComponentConditions(conditions, pool.Component)
-		return err
-	}
-
-	ready, err = services.PreparePodForDeleteByIp(r.osClient, podIp, r.instance.Spec.General.DrainDataNodes, dataCount)
+	ready, err = services.PreparePodForDelete(r.osClient, workingPod, r.instance.Spec.General.DrainDataNodes, dataCount)
 	if err != nil {
 		conditions = append(conditions, "Could not prepare pod for delete")
 		r.setComponentConditions(conditions, pool.Component)
@@ -414,9 +406,8 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opsterv1.NodePool) error {
 	r.setComponentConditions(conditions, pool.Component)
 
 	// If we are draining nodes remove the exclusion after the pod is deleted
-	// CRITEO WORKAROUND: use node ip
 	if r.instance.Spec.General.DrainDataNodes {
-		_, err = services.RemoveExcludeNodeHostIp(r.osClient, podIp)
+		_, err = services.RemoveExcludeNodeHost(r.osClient, workingPod)
 		return err
 	}
 


### PR DESCRIPTION
not needed anymore, node name is properly initialized with pod name

This reverts commit 519e3540c4c5cf0676add2309278f1c6af53beb0.