### PR TITLE
multiple fixes to properly support multi-node scale down operations

### DIFF
--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Cluster Reconciler", func() {
 
 			Eventually(func() bool {
 				stsList := &appsv1.StatefulSetList{}
-				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Name))
+				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Namespace))
 				if err != nil {
 					return false
 				}

--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Cluster Reconciler", func() {
 
 			Eventually(func() bool {
 				stsList := &appsv1.StatefulSetList{}
-				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Namespace))
+				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Name))
 				if err != nil {
 					return false
 				}

--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -182,20 +182,6 @@ func CheckClusterStatusForRestart(service *OsClusterClient, drainNodes bool) (bo
 	return false, "enabled shard allocation", nil
 }
 
-// CRITEO WORKAROUND: check Green cluster status for Scaler
-func IsClusterGreen(service *OsClusterClient) (bool, string, error) {
-	health, err := service.GetHealth()
-	if err != nil {
-		return false, "failed to fetch health", err
-	}
-
-	if health.Status == "green" {
-		return true, "", nil
-	}
-
-	return false, "cluster not green", nil
-}
-
 func ReactivateShardAllocation(service *OsClusterClient) error {
 	flatSettings, err := service.GetFlatClusterSettings()
 	if err != nil {

--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"strings"
 
 	"opensearch.opster.io/opensearch-gateway/responses"
@@ -40,7 +41,17 @@ func HasShardsOnNode(service *OsClusterClient, nodeName string) (bool, error) {
 		if shardsData.NodeName == nodeName {
 			return true, err
 		}
+
+		if shardsData.State == "RELOCATING" {
+			// syntax of name column is a bit different when shard is relocating
+			// source_node_name -> dest_node_ip dest_node_id dest_node_name
+			prefix := fmt.Sprintf("%s ", nodeName)
+			if strings.HasPrefix(shardsData.NodeName, prefix) || strings.HasSuffix(shardsData.NodeName, nodeName) {
+				return true, err
+			}
+		}
 	}
+
 	return false, err
 }
 

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -283,11 +283,6 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 		lg.Info(fmt.Sprintf("Group-%s . draining node %s", nodePoolGroupName, lastReplicaNodeName))
 		return err
 	}
-	success, err := services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
-	if !success {
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Group-%s . node %s node is empty but node is still excluded from allocation", nodePoolGroupName, lastReplicaNodeName)
-		return err
-	}
 
 	componentStatus := opsterv1.ComponentStatus{
 		Component:   "Scaler",

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -138,7 +138,6 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool,
 		err := r.drainNode(currentStatus, currentSts, nodePool.Component)
 		return true, err
 	}
-
 	if currentStatus.Status == "Drained" {
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Start to Drain %s/%s", r.instance.Namespace, r.instance.Name)
 
@@ -284,14 +283,6 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 		lg.Info(fmt.Sprintf("Group-%s . draining node %s", nodePoolGroupName, lastReplicaNodeName))
 		return err
 	}
-
-	// CRITEO WORKAROUND: Wait for cluster to be green
-	clusterNotGreen, _, err := services.IsClusterGreen(clusterClient)
-	if clusterNotGreen {
-		lg.Info(fmt.Sprintf("Group-%s . draining node %s", nodePoolGroupName, lastReplicaNodeName))
-		return err
-	}
-
 	success, err := services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
 	if !success {
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Group-%s . node %s node is empty but node is still excluded from allocation", nodePoolGroupName, lastReplicaNodeName)
@@ -319,8 +310,7 @@ func (r *ScalerReconciler) cleanupStatefulSets(result *reconciler.CombinedResult
 	if err := r.Client.List(
 		r.ctx,
 		stsList,
-		// CRITEO WORKAROUND: use "Namespace" instead of "Name"
-		client.InNamespace(r.instance.Namespace),
+		client.InNamespace(r.instance.Name),
 		client.MatchingLabels{helpers.ClusterLabel: r.instance.Name},
 	); err != nil {
 		result.Combine(&ctrl.Result{}, err)
@@ -376,21 +366,6 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 			RequeueAfter: 15 * time.Second,
 		}, nil
 	}
-
-	// CRITEO WORKAROUND: Wait for cluster to be green
-	clusterNotGreen, msg, err := services.IsClusterGreen(clusterClient)
-	if err != nil {
-		lg.Error(err, msg)
-		return nil, err
-	}
-
-	if clusterNotGreen {
-		return &ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: 15 * time.Second,
-		}, nil
-	}
-	// END OF CRITEO WORKAROUND
 
 	if workingOrdinal == 0 {
 		result, err := r.ReconcileResource(&sts, reconciler.StateAbsent)

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -83,6 +83,34 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool,
 	comp := r.instance.Status.ComponentsStatus
 	currentStatus, found := helpers.FindFirstPartial(comp, componentStatus, helpers.GetByDescriptionAndGroup)
 
+	if currentStatus.Status == "Waiting" {
+		if currentSts.Status.ReadyReplicas != *currentSts.Spec.Replicas {
+			// pods are coming up or getting deleted, continue to wait
+			lg.Info(fmt.Sprintf("Group-%s . waiting to have correct number of readyPods %d/%d to continue scaling", nodePool.Component, currentSts.Status.ReadyReplicas, *currentSts.Spec.Replicas))
+			return true, nil
+		}
+
+		if r.instance.Spec.ConfMgmt.SmartScaler {
+			// stable point reached during down scale, remove previous node from exclusion
+			err := r.cleanupExclusionList(currentSts, nodePool.Component)
+			if err != nil {
+				lg.Error(err, "failed to cleanup exclusion list")
+				return true, err
+			}
+		}
+
+		// Change the status to running and reconcile again
+		componentStatus.Status = "Running"
+		r.instance.Status.ComponentsStatus = helpers.Replace(currentStatus, componentStatus, r.instance.Status.ComponentsStatus)
+		err := r.Status().Update(r.ctx, r.instance)
+		if err != nil {
+			lg.Error(err, "failed to update status")
+			return false, err
+		}
+		lg.Info(fmt.Sprintf("Group-%s . resuming scaling", nodePool.Component))
+		return true, nil
+	}
+
 	var desireReplicaDiff = *currentSts.Spec.Replicas - nodePool.Replicas
 	if desireReplicaDiff == 0 {
 		// If a scaling operation was started before for this nodePool
@@ -176,34 +204,52 @@ func (r *ScalerReconciler) decreaseOneNode(currentStatus opsterv1.ComponentStatu
 		return true, err
 	}
 	lg.Info(fmt.Sprintf("Group-%s . removed node %s", nodePoolGroupName, lastReplicaNodeName))
-	r.instance.Status.ComponentsStatus = helpers.RemoveIt(currentStatus, r.instance.Status.ComponentsStatus)
+
+	if smartDecrease {
+		// switch state machine to Waiting state as we need to wait for node to be effectively down to remove it from exclusion list
+		componentStatus := opsterv1.ComponentStatus{
+			Component:   "Scaler",
+			Status:      "Waiting",
+			Description: nodePoolGroupName,
+		}
+		r.instance.Status.ComponentsStatus = helpers.Replace(currentStatus, componentStatus, r.instance.Status.ComponentsStatus)
+	} else {
+		r.instance.Status.ComponentsStatus = helpers.RemoveIt(currentStatus, r.instance.Status.ComponentsStatus)
+	}
 	err = r.Status().Update(r.ctx, r.instance)
 	if err != nil {
 		lg.Error(err, "failed to update status")
 		return false, err
 	}
 
-	if !smartDecrease {
-		return false, err
-	}
+	return smartDecrease, err
+}
+
+func (r *ScalerReconciler) cleanupExclusionList(currentSts appsv1.StatefulSet, nodePoolGroupName string) error {
+	lg := log.FromContext(r.ctx)
+	annotations := map[string]string{"cluster-name": r.instance.GetName()}
+	lastReplicaNodeName := helpers.ReplicaHostName(currentSts, *currentSts.Spec.Replicas)
+
 	username, password, err := helpers.UsernameAndPassword(r.ctx, r.Client, r.instance)
 	if err != nil {
-		return true, err
+		return err
 	}
+
 	clusterClient, err := services.NewOsClusterClient(builders.URLForCluster(r.instance), username, password)
 	if err != nil {
 		lg.Error(err, "failed to create os client")
 		r.recorder.AnnotatedEventf(r.instance, annotations, "WARN", "failed to remove node exclude", "Group-%s . failed to remove node exclude %s", nodePoolGroupName, lastReplicaNodeName)
-		return true, err
+		return err
 	}
 
 	success, err := services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
 	if !success || err != nil {
 		lg.Error(err, fmt.Sprintf("failed to remove exclude node %s", lastReplicaNodeName))
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to remove node exclude - Group-%s , node  %s", nodePoolGroupName, lastReplicaNodeName)
+		return err
 	}
 
-	return false, err
+	return err
 }
 
 func (r *ScalerReconciler) excludeNode(currentStatus opsterv1.ComponentStatus, currentSts appsv1.StatefulSet, nodePoolGroupName string) error {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -310,7 +310,7 @@ func (r *ScalerReconciler) cleanupStatefulSets(result *reconciler.CombinedResult
 	if err := r.Client.List(
 		r.ctx,
 		stsList,
-		client.InNamespace(r.instance.Name),
+		client.InNamespace(r.instance.Namespace),
 		client.MatchingLabels{helpers.ClusterLabel: r.instance.Name},
 	); err != nil {
 		result.Combine(&ctrl.Result{}, err)

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -286,8 +286,8 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 	}
 
 	// CRITEO WORKAROUND: Wait for cluster to be green
-	clusterGreen, _, err := services.IsClusterGreen(clusterClient)
-	if !clusterGreen {
+	clusterNotGreen, _, err := services.IsClusterGreen(clusterClient)
+	if clusterNotGreen {
 		lg.Info(fmt.Sprintf("Group-%s . draining node %s", nodePoolGroupName, lastReplicaNodeName))
 		return err
 	}
@@ -378,13 +378,13 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	}
 
 	// CRITEO WORKAROUND: Wait for cluster to be green
-	clusterGreen, msg, err := services.IsClusterGreen(clusterClient)
+	clusterNotGreen, msg, err := services.IsClusterGreen(clusterClient)
 	if err != nil {
 		lg.Error(err, msg)
 		return nil, err
 	}
 
-	if !clusterGreen {
+	if clusterNotGreen {
 		return &ctrl.Result{
 			Requeue:      true,
 			RequeueAfter: 15 * time.Second,

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -145,6 +145,18 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool,
 		}
 
 		if desireReplicaDiff > 0 {
+			isSafe, err := r.isScaleDownSafe()
+			if err != nil {
+				r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Scaler", "Failed to determine if cluster is green")
+				lg.Error(err, "failed to get cluster state")
+				return true, err
+			}
+
+			if !isSafe {
+				lg.Info(fmt.Sprintf("Group-%s . delaying scale down - cluster is not in good shape", nodePool.Component))
+				return true, nil
+			}
+
 			r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Starting to scaling")
 			if !r.instance.Spec.ConfMgmt.SmartScaler {
 				requeue, err := r.decreaseOneNode(currentStatus, currentSts, nodePool.Component, r.instance.Spec.ConfMgmt.SmartScaler)
@@ -152,7 +164,8 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool,
 				r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Starting to decrease node")
 				return requeue, err
 			}
-			err := r.excludeNode(currentStatus, currentSts, nodePool.Component)
+
+			err = r.excludeNode(currentStatus, currentSts, nodePool.Component)
 			return true, err
 
 		}
@@ -223,6 +236,32 @@ func (r *ScalerReconciler) decreaseOneNode(currentStatus opsterv1.ComponentStatu
 	}
 
 	return smartDecrease, err
+}
+
+func (r *ScalerReconciler) isScaleDownSafe() (bool, error) {
+	lg := log.FromContext(r.ctx)
+
+	username, password, err := helpers.UsernameAndPassword(r.ctx, r.Client, r.instance)
+	if err != nil {
+		return false, err
+	}
+
+	clusterClient, err := services.NewOsClusterClient(builders.URLForCluster(r.instance), username, password)
+	if err != nil {
+		lg.Error(err, "failed to create os client")
+		return false, err
+	}
+
+	health, err := clusterClient.GetHealth()
+	if err != nil {
+		return false, err
+	}
+
+	if health.Status != "green" {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (r *ScalerReconciler) cleanupExclusionList(currentSts appsv1.StatefulSet, nodePoolGroupName string) error {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -54,10 +54,10 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	for _, nodePool := range r.instance.Spec.NodePools {
 		requeue, err = r.reconcileNodePool(&nodePool)
 		if err != nil {
-			results.Combine(&ctrl.Result{Requeue: requeue}, err)
+			results.Combine(&ctrl.Result{Requeue: requeue, RequeueAfter: 1 * time.Second}, err)
 		}
 	}
-	results.Combine(&ctrl.Result{Requeue: requeue}, nil)
+	results.Combine(&ctrl.Result{Requeue: requeue, RequeueAfter: 1 * time.Second}, nil)
 
 	// Clean up old node pools
 	r.cleanupStatefulSets(results)


### PR DESCRIPTION
* reverted initial attempts to fix scale down to ease integration of upstream fixes
* integrated two fixes from opensearch-k8s-operator v2..5.0
* fix detection of relocating shards
* delay re-enqueue when all conditions for scale down aren't met to increase chances to have a consistent cache
* fix cluster passing red during multi-node scale down
* prevent scaler to initiate downscale if cluster is not green

The last 4 commits are candidate for upstream contribution, but we need to catch-up with upstream first and unit tests coverage will have to be increased.