### PR TITLE
Make host networking configurable via OpenSearchCluster

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -57,6 +57,8 @@ spec:
                     description: Extra items to add to the opensearch.yml, defaults
                       to General.AdditionalConfig
                     type: object
+                  hostNetwork:
+                    type: boolean
                   affinity:
                     description: Affinity is a group of affinity scheduling rules.
                     properties:
@@ -1217,6 +1219,8 @@ spec:
                       - path
                       type: object
                     type: array
+                  hostNetwork:
+                    type: boolean
                   affinity:
                     description: Affinity is a group of affinity scheduling rules.
                     properties:
@@ -3341,6 +3345,8 @@ spec:
                             type: string
                         type: object
                     type: object
+                  hostNetwork:
+                    type: boolean
                   serviceAccount:
                     type: string
                   serviceName:
@@ -3456,6 +3462,8 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    hostNetwork:
+                      type: boolean
                     affinity:
                       description: Affinity is a group of affinity scheduling rules.
                       properties:

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -38,6 +38,7 @@ type GeneralConfig struct {
 	Vendor           string  `json:"vendor,omitempty"`
 	Version          string  `json:"version,omitempty"`
 	ServiceAccount   string  `json:"serviceAccount,omitempty"`
+	HostNetwork      *bool   `json:"hostNetwork,omitempty"`
 	ServiceName      string  `json:"serviceName"`
 	SetVMMaxMapCount bool    `json:"setVMMaxMapCount,omitempty"`
 	DefaultRepo      *string `json:"defaultRepo,omitempty"`
@@ -81,6 +82,7 @@ type NodePool struct {
 	Tolerations               []corev1.Toleration               `json:"tolerations,omitempty"`
 	NodeSelector              map[string]string                 `json:"nodeSelector,omitempty"`
 	Affinity                  *corev1.Affinity                  `json:"affinity,omitempty"`
+	HostNetwork               *bool                             `json:"hostNetwork,omitempty"`
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	Persistence               *PersistenceConfig                `json:"persistence,omitempty"`
 	AdditionalConfig          map[string]string                 `json:"additionalConfig,omitempty"`
@@ -131,6 +133,7 @@ type BootstrapConfig struct {
 	Resources    corev1.ResourceRequirements `json:"resources,omitempty"`
 	Tolerations  []corev1.Toleration         `json:"tolerations,omitempty"`
 	NodeSelector map[string]string           `json:"nodeSelector,omitempty"`
+	HostNetwork  *bool                       `json:"hostNetwork,omitempty"`
 	Affinity     *corev1.Affinity            `json:"affinity,omitempty"`
 	Jvm          string                      `json:"jvm,omitempty"`
 	// Extra items to add to the opensearch.yml, defaults to General.AdditionalConfig
@@ -162,6 +165,7 @@ type DashboardsConfig struct {
 	Tolerations                 []corev1.Toleration         `json:"tolerations,omitempty"`
 	NodeSelector                map[string]string           `json:"nodeSelector,omitempty"`
 	Affinity                    *corev1.Affinity            `json:"affinity,omitempty"`
+	HostNetwork                 *bool                       `json:"hostNetwork,omitempty"`
 	Labels                      map[string]string           `json:"labels,omitempty"`
 	Annotations                 map[string]string           `json:"annotations,omitempty"`
 	Service                     DashboardsServiceSpec       `json:"service,omitempty"`

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -57,6 +57,8 @@ spec:
                     description: Extra items to add to the opensearch.yml, defaults
                       to General.AdditionalConfig
                     type: object
+                  hostNetwork:
+                    type: boolean
                   affinity:
                     description: Affinity is a group of affinity scheduling rules.
                     properties:
@@ -1217,6 +1219,8 @@ spec:
                       - path
                       type: object
                     type: array
+                  hostNetwork:
+                    type: boolean
                   affinity:
                     description: Affinity is a group of affinity scheduling rules.
                     properties:
@@ -3341,6 +3345,8 @@ spec:
                             type: string
                         type: object
                     type: object
+                  hostNetwork:
+                    type: boolean
                   serviceAccount:
                     type: string
                   serviceName:
@@ -3456,6 +3462,8 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    hostNetwork:
+                      type: boolean
                     affinity:
                       description: Affinity is a group of affinity scheduling rules.
                       properties:

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -352,6 +352,14 @@ func NewSTSForNodePool(
 		initContainers = append(initContainers, keystoreInitContainer)
 	}
 
+	// CRITEO WORKAROUND
+	hostNetwork := true
+	if node.HostNetwork != nil {
+		hostNetwork = *node.HostNetwork
+	} else if cr.Spec.General.HostNetwork != nil {
+		hostNetwork = *cr.Spec.General.HostNetwork
+	}
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name + "-" + node.Component,
@@ -433,8 +441,7 @@ func NewSTSForNodePool(
 							SecurityContext: securityContext,
 						},
 					},
-					HostNetwork:               true,                              // CRITEO WORKAROUND
-					DNSPolicy:                 corev1.DNSClusterFirstWithHostNet, // CRITEO WORKAROUND
+					HostNetwork:               hostNetwork,                       // CRITEO WORKAROUND
 					InitContainers:            initContainers,
 					Volumes:                   volumes,
 					ServiceAccountName:        cr.Spec.General.ServiceAccount,
@@ -455,6 +462,11 @@ func NewSTSForNodePool(
 			}(),
 			ServiceName: cr.Spec.General.ServiceName,
 		},
+	}
+
+	// CRITEO WORKAROUND
+	if hostNetwork {
+		sts.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	// Append additional config to env vars
@@ -768,6 +780,14 @@ func NewBootstrapPod(
 		})
 	}
 
+	// CRITEO WORKAROUND
+	hostNetwork := true
+	if cr.Spec.Bootstrap.HostNetwork != nil {
+		hostNetwork = *cr.Spec.Bootstrap.HostNetwork
+	} else if cr.Spec.General.HostNetwork != nil {
+		hostNetwork = *cr.Spec.General.HostNetwork
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      BootstrapPodName(cr),
@@ -798,8 +818,7 @@ func NewBootstrapPod(
 					SecurityContext: securityContext,
 				},
 			},
-			HostNetwork:        true,                              // CRITEO WORKAROUND
-			DNSPolicy:          corev1.DNSClusterFirstWithHostNet, // CRITEO WORKAROUND
+			HostNetwork:        hostNetwork,                       // CRITEO WORKAROUND
 			InitContainers:     initContainers,
 			Volumes:            volumes,
 			ServiceAccountName: cr.Spec.General.ServiceAccount,
@@ -809,6 +828,11 @@ func NewBootstrapPod(
 			ImagePullSecrets:   image.ImagePullSecrets,
 			SecurityContext:    podSecurityContext,
 		},
+	}
+
+	// CRITEO WORKAROUND
+	if hostNetwork {
+		pod.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	if cr.Spec.General.SetVMMaxMapCount {
@@ -928,7 +952,13 @@ func NewSnapshotRepoconfigUpdateJob(
 	podSecurityContext := instance.Spec.General.PodSecurityContext
 	securityContext := instance.Spec.General.SecurityContext
 
-	return batchv1.Job{
+	// CRITEO WORKAROUND
+	hostNetwork := true
+	if instance.Spec.Dashboards.HostNetwork != nil {
+		hostNetwork = *instance.Spec.General.HostNetwork
+	}
+
+	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: namespace, Annotations: annotations},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &backoffLimit,
@@ -949,12 +979,18 @@ func NewSnapshotRepoconfigUpdateJob(
 					RestartPolicy:      corev1.RestartPolicyNever,
 					Volumes:            volumes,
 					SecurityContext:    podSecurityContext,
-					HostNetwork:        true,                              // CRITEO WORKAROUND
-					DNSPolicy:          corev1.DNSClusterFirstWithHostNet, // CRITEO WORKAROUND
+					HostNetwork:        hostNetwork,                       // CRITEO WORKAROUND
 				},
 			},
 		},
 	}
+
+	// CRITEO WORKAROUND
+	if hostNetwork {
+		job.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	}
+
+	return job
 }
 
 func NewSecurityconfigUpdateJob(
@@ -992,7 +1028,13 @@ func NewSecurityconfigUpdateJob(
 	securityContext := instance.Spec.General.SecurityContext
 	podSecurityContext := instance.Spec.General.PodSecurityContext
 
-	return batchv1.Job{
+	// CRITEO WORKAROUND
+	hostNetwork := true
+	if instance.Spec.Dashboards.HostNetwork != nil {
+		hostNetwork = *instance.Spec.General.HostNetwork
+	}
+
+	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: namespace, Annotations: annotations},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &backoffLimit,
@@ -1014,12 +1056,18 @@ func NewSecurityconfigUpdateJob(
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ImagePullSecrets:   image.ImagePullSecrets,
 					SecurityContext:    podSecurityContext,
-					HostNetwork:        true,                              // CRITEO WORKAROUND
-					DNSPolicy:          corev1.DNSClusterFirstWithHostNet, // CRITEO WORKAROUND
+					HostNetwork:        hostNetwork,                       // CRITEO WORKAROUND
 				},
 			},
 		},
 	}
+
+	// CRITEO WORKAROUND
+	if hostNetwork {
+		job.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	}
+
+	return job
 }
 
 func AllMastersReady(ctx context.Context, k8sClient client.Client, cr *opsterv1.OpenSearchCluster) bool {

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -121,7 +121,15 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 
 	mainCommand := helpers.BuildMainCommandOSD("./bin/opensearch-dashboards-plugin", cr.Spec.Dashboards.PluginsList, "./opensearch-dashboards-docker-entrypoint.sh")
 
-	return &appsv1.Deployment{
+	// CRITEO WORKAROUND
+	hostNetwork := true
+	if cr.Spec.Dashboards.HostNetwork != nil {
+		hostNetwork = *cr.Spec.Dashboards.HostNetwork
+	} else if cr.Spec.General.HostNetwork != nil {
+		hostNetwork = *cr.Spec.General.HostNetwork
+	}
+
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name + "-dashboards",
 			Namespace: cr.Namespace,
@@ -142,8 +150,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 				},
 				Spec: corev1.PodSpec{
 					Volumes:     volumes,
-					HostNetwork: true,                              // CRITEO WORKAROUND
-					DNSPolicy:   corev1.DNSClusterFirstWithHostNet, // CRITEO WORKAROUND
+					HostNetwork: hostNetwork,                              // CRITEO WORKAROUND
 					Containers: []corev1.Container{
 						{
 							Name:            "dashboards",
@@ -174,6 +181,13 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 			},
 		},
 	}
+
+	// CRITEO WORKAROUND
+	if hostNetwork {
+		deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+	}
+
+	return deployment
 }
 
 func NewDashboardsConfigMapForCR(cr *opsterv1.OpenSearchCluster, name string, config map[string]string) *corev1.ConfigMap {


### PR DESCRIPTION
OpenSearch operator doesn't offer the possibility to configure host networking.
So at first, we hardcoded the value to true to make OpenSearch work on our pipelines.

With the arrival of Cilium, we want to have the possibility to configure freely the host networking of
an OpenSearch cluster.

We can override the hostNetwork attribute in 4 different places:
  * bootstrap
  * dashboards
  * general
  * by nodePool

If the hostNetwork attribute is set in the nodePool/dashboards and in the general config,
the nodePool/dashboards configuration takes priority.

The configuration still works like before if the hostNetwork attribute is not
set at all (hostNetwork is set to true by default).